### PR TITLE
Fix test failure due to ASI not happening

### DIFF
--- a/src/__tests__/NewMessageForm.spec.js
+++ b/src/__tests__/NewMessageForm.spec.js
@@ -19,7 +19,7 @@ describe('<NewMessageForm onSend={sendHandler} />', () => {
 
         beforeEach( async () => {
 
-            sendHandler = jest.fn().mockName('sendHandler')
+            sendHandler = jest.fn().mockName('sendHandler');
 
             ({ getByTestId } = render(<NewMessageForm onSend={sendHandler}/>))
 


### PR DESCRIPTION
I'm not at my computer but I'm pretty sure adding this semicolon fixes it.

In my understanding, in general semicolons can be omitted from JS. One of the few cases where they can't is when a line starts with an open paren. This is because it's valid to consider it calling the previous line as a function.

As a result, your mock function is called, and the _result_ of that (undefined) is assigned to the variable.

To learn more about this dynamic, see http://inimino.org/~inimino/blog/javascript_semicolons starting at "The potential for error arises"